### PR TITLE
make it work properly in npm

### DIFF
--- a/index.js
+++ b/index.js
@@ -133,3 +133,7 @@ TextDecoderLite.prototype.decode = function (bytes) {
 }
 
 }());
+
+if(typeof module === "object" && module) {  
+  module.exports = TextDecoderLite
+}


### PR DESCRIPTION
Normally you can access a module installed with npm like this:
```javascript
require('text-decoder-lite')
```
But right now this doesn't work because your code doesn't define it's exports.  There's no way to access it when installed with npm. This change fixes that.